### PR TITLE
Fix devices example build failure

### DIFF
--- a/examples/devices.d
+++ b/examples/devices.d
@@ -93,7 +93,7 @@ int main() {
 		if (properties.queueFlags & VK_QUEUE_GRAPHICS_BIT) {
 			writeln("\tVK_QUEUE_GRAPHICS_BIT");
 			if (graphicsQueueFamilyIndex == uint.max) {
-				graphicsQueueFamilyIndex = i;
+				graphicsQueueFamilyIndex = cast(uint)i;
 			}
 		}
 


### PR DESCRIPTION
This fixes the following build error: 
```
 swoorup  ⋯  dlang_experiments  3rd_party  ErupteD  dub run erupted:devices                     069bc86 
Building package erupted:devices in /home/swoorup/projects/dlang_experiments/3rd_party/ErupteD/
Performing "debug" build using dmd for x86_64.
derelict-util 2.0.6: target for configuration "library" is up to date.
erupted:devices 1.4.8: building configuration "application"...
examples/devices.d(96,32): Error: cannot implicitly convert expression (i) of type ulong to uint
examples/devices.d(16,5): Error: function D main no return exp; or assert(0); at end of function
dmd failed with exit code 1.

```