### PR TITLE
Using wayland:client for wayland bindings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use with the `with-derelict-loader` configuration, follow the above steps, bu
 
 Available configurations:
 * `with-derelict-loader` fetches derelictUtil, gets a pointer to `vkGetInstanceProcAddr` and loads few additional global functions (see above)
-* `dub-platform-xcb`, `dub-platform-xlib`, `dub-platform-wayland` fetches corresponding dub packages `xcb-d`, `xlib-d`, `wayland-client-d`, see [Platform surface extensions](https://github.com/ParticlePeter/ErupteD#platform-surface-extensions)
+* `dub-platform-xcb`, `dub-platform-xlib`, `dub-platform-wayland` fetches corresponding dub packages `xcb-d`, `xlib-d`, `wayland:client`, see [Platform surface extensions](https://github.com/ParticlePeter/ErupteD#platform-surface-extensions)
 * `dub-platform-???-derelict-loader` combines the platforms above with the derelict loader
 
 The API is similar to the C Vulkan API, but with some differences:
@@ -102,7 +102,7 @@ Additional info:
 * for windows platform, in your project specify:
 `"versions" : [ "VK_USE_PLATFORM_WIN32_KHR" ]`.
 The phobos windows modules will be used in that case.
-* wayland-client.h cannot exist as module name. The maintainer of `wayland-client-d` choose `wayland.client` as module name and the name is used in `erupted/types` as well.
+* wayland-client.h cannot exist as module name. The maintainer of `wayland:client` choose `wayland.client` as module name and the name is used in `erupted/types` as well.
 * for android platform, I have not a single clue how this is supposed to work. If you are interested in android and have an idea how it should work feel free to open up an issue.
 
 

--- a/_dub.json
+++ b/_dub.json
@@ -38,7 +38,7 @@
             "name"          :   "dub-platform-wayland",
             "versions"      :   [ "VK_USE_PLATFORM_WAYLAND_KHR" ],
             "dependencies"  :   {
-                "wayland-client-d"  : "~>1.8.90"
+                "wayland:client"  : "~>0.1.0"
             }
         },
 
@@ -64,7 +64,7 @@
             "name"          :   "dub-platform-wayland-derelict-loader",
             "versions"      :   [ "VK_USE_PLATFORM_WAYLAND_KHR", "ERUPTED_FROM_DERELICT" ],
             "dependencies"  :   {
-                "wayland-client-d"  : "~>1.8.90",
+                "wayland:client"  : "~>0.1.0",
                 "derelict-util"     : "~>2.0.4"
             }
         },

--- a/dub.sdl
+++ b/dub.sdl
@@ -4,7 +4,7 @@ copyright		"Copyright 2015-2016 The Khronos Group Inc.; Copyright 2016 Alex Parr
 authors			"Alex Parrill" "Peter Particle"
 targetType		"sourceLibrary"
 license			"BSD 2-clause"
-	
+
 // load vulkan vkGetInstanceProcAddr manually os specific or with glfw or similar
 configuration	"default"
 
@@ -14,7 +14,7 @@ configuration	"with-derelict-loader" {
 	dependency		"derelict-util"		version = "~>2.0.4"
 }
 
-// enable xlib specific functionality 
+// enable xlib specific functionality
 configuration	"dub-platform-xlib" {
 	versions		"VK_USE_PLATFORM_XLIB_KHR"
 	dependency		"xlib-d"			version = "~>0.1.1"
@@ -29,7 +29,7 @@ configuration	"dub-platform-xcb" {
 // enable wayland specific functionality
 configuration	"dub-platform-wayland" {
 	versions		"VK_USE_PLATFORM_WAYLAND_KHR"
-	dependency		"wayland-client-d"	version = "~>1.8.90"
+	dependency		"wayland:client"	version = "~>0.1.0"
 }
 
 // enable xlib specific functionality load vkGetInstanceProcAddr with derelict
@@ -49,7 +49,7 @@ configuration	"dub-platform-xcb-derelict-loader" {
 // enable wayland specific functionality load vkGetInstanceProcAddr with derelict
 configuration	"dub-platform-wayland-derelict-loader" {
 	versions		"VK_USE_PLATFORM_WAYLAND_KHR"  "ERUPTED_FROM_DERELICT"
-	dependency		"wayland-client-d"	version = "~>1.8.90"
+	dependency		"wayland:client"	version = "~>0.1.0"
 	dependency		"derelict-util"		version = "~>2.0.4"
 }
 

--- a/erupt.py
+++ b/erupt.py
@@ -153,7 +153,7 @@ class DGenerator( OutputGenerator ):
 		self.platformExtensions = {
 			"// VK_KHR_android_surface"          : [ "VK_USE_PLATFORM_ANDROID_KHR", "public import android.native_window;\n" ],
 			"// VK_KHR_mir_surface"              : [ "VK_USE_PLATFORM_MIR_KHR",     "public import mir_toolkit.client_types;\n" ],
-			"// VK_KHR_wayland_surface"          : [ "VK_USE_PLATFORM_WAYLAND_KHR", "public import wayland.client;\n" ],
+			"// VK_KHR_wayland_surface"          : [ "VK_USE_PLATFORM_WAYLAND_KHR", "public import wayland.native.client;\n" ],
 			"// VK_KHR_win32_surface"            : [ "VK_USE_PLATFORM_WIN32_KHR",   "public import core.sys.windows.windows;\n" ],
 			"// VK_KHR_xlib_surface"             : [ "VK_USE_PLATFORM_XLIB_KHR",    "public import X11.Xlib;\n" ],
 			"// VK_EXT_acquire_xlib_display"     : [ "VK_USE_PLATFORM_XLIB_KHR" ,   "" ],
@@ -369,7 +369,13 @@ version( {NAME_PREFIX_UCASE}_FROM_DERELICT ) {{
 					if section == 'struct':
 						if self.opaqueStruct:
 							for opaque in self.opaqueStruct:
-								fileContent += "{1}struct {0};\n".format( opaque, extIndent )
+								# special handling for wayland
+								if opaque == "wl_display":
+									continue
+								elif opaque == "wl_surface":
+									fileContent += "{0}alias wl_surface = wl_proxy;\n".format( extIndent );
+								else:
+									fileContent += "{1}struct {0};\n".format( opaque, extIndent )
 							fileContent += '\n'
 
 					elif not isFirstSectionInFeature:

--- a/source/erupted/types.d
+++ b/source/erupted/types.d
@@ -4038,14 +4038,13 @@ version( VK_USE_PLATFORM_XCB_KHR ) {
 
 // VK_KHR_wayland_surface
 version( VK_USE_PLATFORM_WAYLAND_KHR ) {
-	public import wayland.client;
+	public import wayland.native.client;
 
 	enum VK_KHR_WAYLAND_SURFACE_SPEC_VERSION = 6;
 	enum VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME = "VK_KHR_wayland_surface";
 
 	alias VkWaylandSurfaceCreateFlagsKHR = VkFlags;
-	struct wl_display;
-	struct wl_surface;
+	alias wl_surface = wl_proxy;
 
 	
 	struct VkWaylandSurfaceCreateInfoKHR {


### PR DESCRIPTION
wayland-client-d is not maintained anymore.
[wayland:client](https://github.com/rtbo/wayland-d) replaces it.