### PR TITLE
Add a note for first time devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ ErupteD
 
 Automatically-generated D bindings for the [Vulkan API](https://www.khronos.org/Vulkan/) based on [D-Vulkan](https://github.com/ColonelThirtyTwo/dvulkan). Acquiring Vulkan functions is based on Intel [API without Secrets](https://software.intel.com/en-us/api-without-secrets-introduction-to-vulkan-part-1).  
 
+Note For devs
+----------------------
+
+To gain access to validation layers, you MUST install the Vulkan SDK. This can be downloaded [here.](https://vulkan.lunarg.com/)
 
 
 Release note v2.x.x


### PR DESCRIPTION
This may seem obvious to you being a very experienced developer, but people like me being a first timer into Vulkan: It's not very obvious that this component is external to the module.

If this PR is shot down, it might cause people that want to learn the new SDK environment using D as their home language to basically just give up because they have no idea why their validation layers are working.

I'll adjust it, move it around, reword it. It would be nice to guide new devs in the right direction.