### PR TITLE
Fix linking [macOS]; fix compiling for aarch64

### DIFF
--- a/source/erupted/types.d
+++ b/source/erupted/types.d
@@ -24,9 +24,9 @@ alias int64_t   = long;
 
 enum VK_NULL_HANDLE = null;
 
-enum VK_DEFINE_HANDLE( string name ) = "struct " ~ name ~ "_handle; alias " ~ name ~ " = " ~ name ~ "_handle*;";
+enum VK_DEFINE_HANDLE( string name ) = "struct " ~ name ~ "_T; alias " ~ name ~ " = " ~ name ~ "_T*;";
 
-version( X86_64 ) {
+version( D_LP64 ) {
     alias VK_DEFINE_NON_DISPATCHABLE_HANDLE( string name ) = VK_DEFINE_HANDLE!name;
     enum VK_NULL_ND_HANDLE = null;
 } else {


### PR DESCRIPTION
Same changes as https://github.com/ParticlePeter/V-Erupt/pull/5.
Vulkan uses `_T` instead of `_handle`, so when linking (e.g. for using ErupteD in a static library with `extern(C++)` declarations) the mangling is incorrect, and the linker fails. This has only been tested on macOS, but should be fine for every other platform.

Additionally, I changed `version(x86_64)` to `version(D_LP64)`. Without this change, aarch64 was treated the same way as a 32-bit platform, which it is not!